### PR TITLE
fix fceu-next crash when load unif format nes rom

### DIFF
--- a/fceumm-code/src/file.c
+++ b/fceumm-code/src/file.c
@@ -443,9 +443,9 @@ static int fread32le(uint32 *Bufo, MEM_TYPE *fp)
 	if (fread(&buf, 1, 4, fp) < 4)
 		return 0;
  #ifdef LSB_FIRST
-	Bufo = buf;
+	*Bufo = buf;
  #else
-	Bufo = ((buf & 0xFF) << 24) | ((buf & 0xFF00) << 8) | ((buf & 0xFF0000) >> 8) | ((buf & 0xFF000000) >> 24);
+	*Bufo = ((buf & 0xFF) << 24) | ((buf & 0xFF00) << 8) | ((buf & 0xFF0000) >> 8) | ((buf & 0xFF000000) >> 24);
  #endif
 	return 1;
 }


### PR DESCRIPTION
win32 platform:.

The problem is read32le() internal will call memstream i/o to handle the stdio file pointer passed from FCEU_read32le().
